### PR TITLE
Yeshhhhu

### DIFF
--- a/app/summarizer/head.tsx
+++ b/app/summarizer/head.tsx
@@ -11,7 +11,7 @@ export default function Head({
   summaryStyle, 
   customDescription 
 }: HeadProps = {}) {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://ai-project-planner.vercel.app";
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://bolt-research-hub.vercel.app";
   const url = `${baseUrl}/summarizer`;
   
   // Dynamic title generation


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the default site URL used in page metadata when NEXT_PUBLIC_SITE_URL is not set. Canonical links, social sharing images (Open Graph), and structured data (JSON-LD: author, publisher, search target, breadcrumbs) now default to the new domain. Behavior is unchanged when the environment variable is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->